### PR TITLE
feat: minimize VS Code extensions

### DIFF
--- a/{{ cookiecutter.__package_name_kebab_case }}/.devcontainer/devcontainer.json
+++ b/{{ cookiecutter.__package_name_kebab_case }}/.devcontainer/devcontainer.json
@@ -8,12 +8,9 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "bungcip.better-toml",
-                "eamodio.gitlens",
-                "ms-azuretools.vscode-docker",
                 "ms-python.python",
-                "ms-python.vscode-pylance",
                 "ryanluker.vscode-coverage-gutters",
+                "tamasfe.even-better-toml",
                 "visualstudioexptteam.vscodeintellicode"
             ],
             "settings": {


### PR DESCRIPTION
Changes with motivation:
1. Replace `bungcip.better-toml` with `tamasfe.even-better-toml` since the former is no longer maintained, and the latter is what the former's author now recommends.
2. Remove GitLens because it now has a premium offering that I don't think we should promote. Users can still install GitLens  themselves of course, it's just no longer a default install.
3. Remove `ms-azuretools.vscode-docker` because `Dockerfile` and `docker-compose.yml` syntax highlighting is built in to VS Code, and we generally don't need docker-in-docker management functions within the Dev Container.
4. Remove `ms-python.vscode-pylance` because it is installed by default together with the `ms-python.python` extension.