### PR TITLE
fix: relock before cz bump

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,8 @@
     "containerEnv": {
         "VIRTUAL_ENV": "/opt/venv",
         "PATH": "/opt/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "UV_PROJECT_ENVIRONMENT": "/opt/venv"
+        "UV_PROJECT_ENVIRONMENT": "/opt/venv",
+        "UV_CACHE_DIR": "/opt/cache"
     },
     "customizations": {
         "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,6 @@
         "VIRTUAL_ENV": "/opt/venv",
         "PATH": "/opt/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
         "UV_PROJECT_ENVIRONMENT": "/opt/venv",
-        "UV_CACHE_DIR": "/opt/cache"
     },
     "customizations": {
         "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,12 @@
     },
     "remoteUser": "root",
     "onCreateCommand": "echo 'eval \"$(starship init bash)\"' >> ~/.bashrc",
-    "postCreateCommand": "uv sync && uv run pre-commit install --install-hooks",
+    "postCreateCommand": "uv sync && pre-commit install --install-hooks",
+    "containerEnv": {
+        "VIRTUAL_ENV": "/opt/venv",
+        "PATH": "/opt/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "UV_PROJECT_ENVIRONMENT": "/opt/venv"
+    },
     "customizations": {
         "vscode": {
             "extensions": [
@@ -36,8 +41,8 @@
                 "github.copilot.chat.edits.codesearch.enabled": true,
                 "github.copilot.chat.edits.enabled": true,
                 "github.copilot.nextEditSuggestions.enabled": true,
-                "python.defaultInterpreterPath": "/workspaces/substrate/.venv/bin/python",
-                "python.terminal.activateEnvironment": true,
+                "python.defaultInterpreterPath": "/opt/venv/bin/python",
+                "python.terminal.activateEnvironment": false,
                 "terminal.integrated.env.linux": {
                     "GIT_EDITOR": "code --wait"
                 },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
 
 [tool.commitizen]
 bump_message = "bump: v$current_version → v$new_version"
-pre_bump_hooks = ["uv lock --offline"]
+pre_bump_hooks = ["uv lock --offline --upgrade-package substrate"]
 tag_format = "v$version"
 update_changelog_on_bump = true
 version_provider = "pep621"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
 
 [tool.commitizen]
 bump_message = "bump: v$current_version → v$new_version"
+hooks_pre_bump = ["uv lock --offline"]
 tag_format = "v$version"
 update_changelog_on_bump = true
 version_provider = "pep621"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
 
 [tool.commitizen]
 bump_message = "bump: v$current_version → v$new_version"
-hooks_pre_bump = ["uv lock --offline"]
+pre_bump_hooks = ["uv lock --offline"]
 tag_format = "v$version"
 update_changelog_on_bump = true
 version_provider = "pep621"

--- a/template/.devcontainer/devcontainer.json.jinja
+++ b/template/.devcontainer/devcontainer.json.jinja
@@ -7,7 +7,6 @@
         {%- if project_type == 'app' %}
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         {%- endif %}
-        "ghcr.io/devcontainers/features/node:1": {},
         "ghcr.io/devcontainers-extra/features/starship": {}
     },
     "overrideCommand": true,

--- a/template/.devcontainer/devcontainer.json.jinja
+++ b/template/.devcontainer/devcontainer.json.jinja
@@ -13,6 +13,9 @@
     "overrideCommand": true,
     "postCreateCommand": "echo 'eval \"$(starship init bash)\"' >> ~/.bashrc",
     "postStartCommand": "uv sync --python ${PYTHON_VERSION:-{{ python_version }}} ${RESOLUTION_STRATEGY:+--resolution $RESOLUTION_STRATEGY} --all-extras && pre-commit install --install-hooks",
+    "containerEnv": {
+        "UV_CACHE_DIR": "/opt/cache"
+    },
     "customizations": {
         "jetbrains": {
             "backend": "PyCharm",

--- a/template/.devcontainer/devcontainer.json.jinja
+++ b/template/.devcontainer/devcontainer.json.jinja
@@ -12,9 +12,6 @@
     "overrideCommand": true,
     "postCreateCommand": "echo 'eval \"$(starship init bash)\"' >> ~/.bashrc",
     "postStartCommand": "uv sync --python ${PYTHON_VERSION:-{{ python_version }}} ${RESOLUTION_STRATEGY:+--resolution $RESOLUTION_STRATEGY} --all-extras && pre-commit install --install-hooks",
-    "containerEnv": {
-        "UV_CACHE_DIR": "/opt/cache"
-    },
     "customizations": {
         "jetbrains": {
             "backend": "PyCharm",

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -62,6 +62,7 @@ dev = [
 
 [tool.commitizen]  # https://commitizen-tools.github.io/commitizen/config/
 bump_message = "bump: v$current_version → v$new_version"
+hooks_pre_bump = ["uv lock --offline"]
 tag_format = "v$version"
 update_changelog_on_bump = true
 version_provider = "pep621"

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -62,7 +62,7 @@ dev = [
 
 [tool.commitizen]  # https://commitizen-tools.github.io/commitizen/config/
 bump_message = "bump: v$current_version → v$new_version"
-hooks_pre_bump = ["uv lock --offline"]
+pre_bump_hooks = ["uv lock --offline"]
 tag_format = "v$version"
 update_changelog_on_bump = true
 version_provider = "pep621"

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -62,7 +62,7 @@ dev = [
 
 [tool.commitizen]  # https://commitizen-tools.github.io/commitizen/config/
 bump_message = "bump: v$current_version → v$new_version"
-pre_bump_hooks = ["uv lock --offline"]
+pre_bump_hooks = ["uv lock --offline --upgrade-package {{ project_name_kebab_case }}"]
 tag_format = "v$version"
 update_changelog_on_bump = true
 version_provider = "pep621"

--- a/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
@@ -83,6 +83,7 @@ priority = "explicit"
 
 [tool.commitizen]  # https://commitizen-tools.github.io/commitizen/config/
 bump_message = "bump: v$current_version → v$new_version"
+hooks_pre_bump = ["uv lock --offline"]
 tag_format = "v$version"
 update_changelog_on_bump = true
 version_provider = "pep621"

--- a/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
+++ b/{{ cookiecutter.__project_name_kebab_case }}/pyproject.toml
@@ -83,7 +83,6 @@ priority = "explicit"
 
 [tool.commitizen]  # https://commitizen-tools.github.io/commitizen/config/
 bump_message = "bump: v$current_version → v$new_version"
-hooks_pre_bump = ["uv lock --offline"]
 tag_format = "v$version"
 update_changelog_on_bump = true
 version_provider = "pep621"


### PR DESCRIPTION
After bumping the version with `cz bump`, uv's lock file is out of sync with `pyproject.toml`. [Until Commitizen adds support for uv](https://github.com/commitizen-tools/commitizen/issues/1349), this PR adds `uv lock --offline` as a [pre bump hook](https://commitizen-tools.github.io/commitizen/commands/bump/#pre_bump_hooks) (which runs after updating the version but before comitting and tagging) to synchronize `uv.lock` and `pyproject.toml`.