### PR TITLE
fix(api): unnecessary default type argument (Ruff UP043)

### DIFF
--- a/template/src/{{ project_name_snake_case }}/{% if with_fastapi_api %}api.py{% endif %}.jinja
+++ b/template/src/{{ project_name_snake_case }}/{% if with_fastapi_api %}api.py{% endif %}.jinja
@@ -9,7 +9,7 @@ from fastapi import FastAPI
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     """Handle FastAPI startup and shutdown events."""
     # Startup events.
     for handler in logging.root.handlers:

--- a/{{ cookiecutter.__project_name_kebab_case }}/src/{{ cookiecutter.__project_name_snake_case }}/api.py
+++ b/{{ cookiecutter.__project_name_kebab_case }}/src/{{ cookiecutter.__project_name_snake_case }}/api.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     """Handle FastAPI startup and shutdown events."""
     # Startup events.
     for handler in logging.root.handlers:


### PR DESCRIPTION
Fixed return type hint of FastAPI `lifespan` function to remove Ruff warning code `UP043`.