### PR TITLE
feat: optimize Dev Container features

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,9 +2,8 @@
     "name": "Substrate",
     "image": "ghcr.io/astral-sh/uv:python3.10-bookworm",
     "features": {
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-        "ghcr.io/devcontainers/features/node:1": {},
-        "ghcr.io/devcontainers-extra/features/starship": {}
+        "ghcr.io/devcontainers-extra/features/devcontainers-cli:1": {},
+        "ghcr.io/devcontainers-extra/features/starship:1": {}
     },
     "remoteUser": "root",
     "onCreateCommand": "echo 'eval \"$(starship init bash)\"' >> ~/.bashrc",
@@ -12,7 +11,7 @@
     "containerEnv": {
         "VIRTUAL_ENV": "/opt/venv",
         "PATH": "/opt/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "UV_PROJECT_ENVIRONMENT": "/opt/venv",
+        "UV_PROJECT_ENVIRONMENT": "/opt/venv"
     },
     "customizations": {
         "vscode": {

--- a/template/.devcontainer/devcontainer.json.jinja
+++ b/template/.devcontainer/devcontainer.json.jinja
@@ -5,9 +5,9 @@
     "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}/",
     "features": {
         {%- if project_type == 'app' %}
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
         {%- endif %}
-        "ghcr.io/devcontainers-extra/features/starship": {}
+        "ghcr.io/devcontainers-extra/features/starship:1": {}
     },
     "overrideCommand": true,
     "postCreateCommand": "echo 'eval \"$(starship init bash)\"' >> ~/.bashrc",

--- a/test.sh
+++ b/test.sh
@@ -29,9 +29,6 @@ for project_type in "${project_types[@]}"; do
         git checkout -b test
         git add .
 
-        # Install the devcontainers CLI
-        npm install -g @devcontainers/cli
-
         # Lint and test the project with a dev container
         devcontainer up --workspace-folder .
         devcontainer exec --workspace-folder . uv lock


### PR DESCRIPTION
Changes:
1. Directly include `devcontainers-cli` as a Dev Container feature instead of `npm`.
2. Don't install the Dev Container CLI in `test.sh` since it will be available by default, and when working without Docker we shouldn't modify the user's system.
3. Replace `docker-in-docker` with `docker-outside-of-docker` for Python apps, which is what the `devcontainers-cli` feature uses too and should be more lightweight than a full install of Docker inside the container.
4. Specify the Starship major version.