### PR TITLE
docs: improve update and migrate commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ uvx copier copy gh:superlinear-ai/substrate path/to/local/repository
 To update your Python project to the latest template version, run:
 
 ```sh
-uvx copier update
+uvx copier update --exclude src/ --exclude tests/
 ```
 
 ### Release a new version of your Python project
@@ -67,8 +67,8 @@ To migrate a project from Cookiecutter to Copier, follow these steps:
     # Create a new branch
     git checkout -b rescaffold
 
-    # Remove files specific to Poetry
-    rm -f poetry.lock
+    # Remove unnecessary files
+    rm -f .cruft.json poetry.lock
     
     # Rescaffold the project without changing src/ and tests/
     uvx copier copy --overwrite --exclude src/ --exclude tests/ gh:superlinear-ai/substrate .
@@ -98,6 +98,7 @@ To migrate a project from Cookiecutter to Copier, follow these steps:
 
 1. [Generate an SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key) and [add the SSH key to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
 2. Configure SSH to automatically load your SSH keys:
+
     ```sh
     cat << EOF >> ~/.ssh/config
     
@@ -108,6 +109,7 @@ To migrate a project from Cookiecutter to Copier, follow these steps:
       ForwardAgent yes
     EOF
     ```
+
 3. [Install Docker Desktop](https://www.docker.com/get-started).
 4. [Install VS Code](https://code.visualstudio.com/) and [VS Code's Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers). Alternatively, install [PyCharm](https://www.jetbrains.com/pycharm/download/).
 5. _Optional:_ install a [Nerd Font](https://www.nerdfonts.com/font-downloads) such as [FiraCode Nerd Font](https://github.com/ryanoasis/nerd-fonts/tree/master/patched-fonts/FiraCode) and [configure VS Code](https://github.com/tonsky/FiraCode/wiki/VS-Code-Instructions) or [PyCharm](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions) to use it.
@@ -118,9 +120,11 @@ To migrate a project from Cookiecutter to Copier, follow these steps:
 <summary>Development environments</summary>
 
 The following development environments are supported:
+
 1. ⭐️ _GitHub Codespaces_: click on [Open in GitHub Codespaces](https://github.com/codespaces/new/superlinear-ai/substrate) to start developing in your browser.
 2. ⭐️ _VS Code Dev Container (with container volume)_: click on [Open in Dev Containers](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/superlinear-ai/substrate) to clone this repository in a container volume and create a Dev Container with VS Code.
 3. ⭐️ _uv_: clone this repository and run the following from root of the repository:
+
     ```sh
     # Create and install a virtual environment
     uv sync
@@ -131,6 +135,7 @@ The following development environments are supported:
     # Install the pre-commit hooks
     pre-commit install --install-hooks
     ```
+
 3. _VS Code Dev Container_: clone this repository, open it with VS Code, and run <kbd>Ctrl/⌘</kbd> + <kbd>⇧</kbd> + <kbd>P</kbd> → _Dev Containers: Reopen in Container_.
 4. _PyCharm Dev Container_: clone this repository, open it with PyCharm, [create a Dev Container with Mount Sources](https://www.jetbrains.com/help/pycharm/start-dev-container-inside-ide.html), and [configure an existing Python interpreter](https://www.jetbrains.com/help/pycharm/configuring-python-interpreter.html#widget) at `/opt/venv/bin/python`.
 

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -61,6 +61,7 @@ import {{ project_name_snake_case }}
 1. [Generate an SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key) and [add the SSH key to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
 {%- endif %}
 1. Configure SSH to automatically load your SSH keys:
+
     ```sh
     cat << EOF >> ~/.ssh/config
     
@@ -71,6 +72,7 @@ import {{ project_name_snake_case }}
       ForwardAgent yes
     EOF
     ```
+
 1. [Install Docker Desktop](https://www.docker.com/get-started).
 1. [Install VS Code](https://code.visualstudio.com/) and [VS Code's Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers). Alternatively, install [PyCharm](https://www.jetbrains.com/pycharm/download/).
 1. _Optional:_ install a [Nerd Font](https://www.nerdfonts.com/font-downloads) such as [FiraCode Nerd Font](https://github.com/ryanoasis/nerd-fonts/tree/master/patched-fonts/FiraCode) and [configure VS Code](https://github.com/tonsky/FiraCode/wiki/VS-Code-Instructions) or [PyCharm](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions) to use it.
@@ -79,11 +81,13 @@ import {{ project_name_snake_case }}
 <summary>Development environments</summary>
 
 The following development environments are supported:
-{% if ci == 'github' %}
+
+{% if ci == 'github' -%}
 1. ⭐️ _GitHub Codespaces_: click on [Open in GitHub Codespaces](https://github.com/codespaces/new/{{ project_url.replace("https://github.com/", "") }}) to start developing in your browser.
 {%- endif %}
 1. ⭐️ _VS Code Dev Container (with container volume)_: click on [Open in Dev Containers](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url={{ project_url }}) to clone this repository in a container volume and create a Dev Container with VS Code.
 1. ⭐️ _uv_: clone this repository and run the following from root of the repository:
+
     ```sh
     # Create and install a virtual environment
     uv sync --python {{ python_version }} --all-extras
@@ -94,6 +98,7 @@ The following development environments are supported:
     # Install the pre-commit hooks
     pre-commit install --install-hooks
     ```
+
 1. _VS Code Dev Container_: clone this repository, open it with VS Code, and run <kbd>Ctrl/⌘</kbd> + <kbd>⇧</kbd> + <kbd>P</kbd> → _Dev Containers: Reopen in Container_.
 1. _PyCharm Dev Container_: clone this repository, open it with PyCharm, [create a Dev Container with Mount Sources](https://www.jetbrains.com/help/pycharm/start-dev-container-inside-ide.html), and [configure an existing Python interpreter](https://www.jetbrains.com/help/pycharm/configuring-python-interpreter.html#widget) at `/opt/venv/bin/python`.
 


### PR DESCRIPTION
Changes:
1. Project update: exclude `src/` and `tests/` when updating since we only provide an initial scaffolding there that is not intended to be updated.
2. Migration from Poetry Cookiecutter: remove `.cruft.json` as we no longer need it.