### PR TITLE
feat: use a non-root user the Dev Container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Substrate",
+    "name": "substrate",
     "image": "ghcr.io/astral-sh/uv:python3.10-bookworm",
     "features": {
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},

--- a/template/.devcontainer/devcontainer.json.jinja
+++ b/template/.devcontainer/devcontainer.json.jinja
@@ -9,8 +9,7 @@
         {%- endif %}
         "ghcr.io/devcontainers-extra/features/starship": {}
     },
-    "overrideCommand": true,
-    "postCreateCommand": "echo 'eval \"$(starship init bash)\"' >> ~/.bashrc",
+    "remoteUser": "user",
     "postStartCommand": "uv sync --python ${PYTHON_VERSION:-{{ python_version }}} ${RESOLUTION_STRATEGY:+--resolution $RESOLUTION_STRATEGY} --all-extras && pre-commit install --install-hooks",
     "customizations": {
         "jetbrains": {

--- a/template/Dockerfile.jinja
+++ b/template/Dockerfile.jinja
@@ -10,11 +10,25 @@ ENV UV_PROJECT_ENVIRONMENT=$VIRTUAL_ENV
 # Tell Git that the workspace is safe to avoid 'detected dubious ownership in repository' warnings.
 RUN git config --system --add safe.directory '*'
 
-# Configure the user's shell.
-RUN echo 'HISTFILE=~/.history/.bash_history' >> ~/.bashrc && \
+# Create a non-root user [1].
+# [1] https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
+RUN groupadd --gid 1000 user && \
+    useradd --create-home --no-log-init --gid 1000 --uid 1000 user && \
+    chown user /opt/
+
+# Give the non-root user passwordless sudo access.
+RUN --mount=type=cache,target=/var/cache/apt/ \
+    --mount=type=cache,target=/var/lib/apt/ \
+    apt-get update && apt-get install --no-install-recommends --yes sudo && \
+    echo 'user ALL=(root) NOPASSWD:ALL' > /etc/sudoers.d/user && chmod 0440 /etc/sudoers.d/user
+USER user
+
+# Configure the non-root user's shell.
+RUN mkdir ~/.history/ && \
+    echo 'HISTFILE=~/.history/.bash_history' >> ~/.bashrc && \
     echo 'bind "\"\e[A\": history-search-backward"' >> ~/.bashrc && \
     echo 'bind "\"\e[B\": history-search-forward"' >> ~/.bashrc && \
-    mkdir ~/.history/
+    echo 'eval "$(starship init bash)"' >> ~/.bashrc
 {%- if project_type == 'app' %}
 
 FROM python:{{ python_version }}-slim AS app
@@ -39,7 +53,7 @@ RUN --mount=type=cache,target=/var/cache/apt/ \
 ARG UID=1000
 ARG GID=$UID
 RUN groupadd --gid $GID user && \
-    useradd --create-home --gid $GID --uid $UID user --no-log-init
+    useradd --create-home --no-log-init --gid $GID --uid $UID user
 USER user
 
 # Set the working directory.

--- a/template/docker-compose.yml.jinja
+++ b/template/docker-compose.yml.jinja
@@ -9,7 +9,7 @@ services:
     {%- endif %}
     volumes:
       - ..:/workspaces
-      - command-history-volume:/root/.history/
+      - command-history-volume:/home/user/.history/
   {%- if project_type == 'app' %}
 
   app:


### PR DESCRIPTION
Closes #281.

Changes:
1. Remove `"overrideCommand": true` as it's the default.
2. Integrate the `"postCreateCommand"` in the Dockerfile and remove it from `devcontainer.json`.
3. Add a non-root user `user` to the Dev Container and select it in `devcontainer.json` with the `"remoteUser"` setting.
