### PR TITLE
fix: fix resolution strategy selection

### DIFF
--- a/template/.devcontainer/devcontainer.json.jinja
+++ b/template/.devcontainer/devcontainer.json.jinja
@@ -9,13 +9,9 @@
         {%- endif %}
         "ghcr.io/devcontainers-extra/features/starship:1": {}
     },
-    "containerEnv": {
-        "PYTHON_VERSION": "${localEnv:PYTHON_VERSION}"{%- if project_type == 'package' %},
-        "RESOLUTION_STRATEGY": "${localEnv:RESOLUTION_STRATEGY}"{%- endif %}
-    },
     "overrideCommand": true,
     "remoteUser": "user",
-    "postStartCommand": "sudo chown -R user:user /opt/ && uv sync --python ${PYTHON_VERSION:-{{ python_version }}} {% if project_type == 'package' %}${RESOLUTION_STRATEGY:+--resolution $RESOLUTION_STRATEGY} {% endif %}--all-extras && pre-commit install --install-hooks",
+    "postStartCommand": "sudo chown -R user:user /opt/ && uv sync --python ${localEnv:PYTHON_VERSION:{{ python_version }}} {% if project_type == 'package' %}--resolution ${localEnv:RESOLUTION_STRATEGY:highest} {% endif %}--all-extras && pre-commit install --install-hooks",
     "customizations": {
         "jetbrains": {
             "backend": "PyCharm",

--- a/template/.devcontainer/devcontainer.json.jinja
+++ b/template/.devcontainer/devcontainer.json.jinja
@@ -9,9 +9,13 @@
         {%- endif %}
         "ghcr.io/devcontainers-extra/features/starship:1": {}
     },
+    "containerEnv": {
+        "PYTHON_VERSION": "${localEnv:PYTHON_VERSION}"{%- if project_type == 'package' %},
+        "RESOLUTION_STRATEGY": "${localEnv:RESOLUTION_STRATEGY}"{%- endif %}
+    },
     "overrideCommand": true,
     "remoteUser": "user",
-    "postStartCommand": "sudo chown -R user:user /opt/ && uv sync --python ${PYTHON_VERSION:-{{ python_version }}} ${RESOLUTION_STRATEGY:+--resolution $RESOLUTION_STRATEGY} --all-extras && pre-commit install --install-hooks",
+    "postStartCommand": "sudo chown -R user:user /opt/ && uv sync --python ${PYTHON_VERSION:-{{ python_version }}} {% if project_type == 'package' %}${RESOLUTION_STRATEGY:+--resolution $RESOLUTION_STRATEGY} {% endif %}--all-extras && pre-commit install --install-hooks",
     "customizations": {
         "jetbrains": {
             "backend": "PyCharm",

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -149,7 +149,10 @@ convention = "numpy"
 [tool.uv]  # https://docs.astral.sh/uv/reference/settings/
 package = true
 
-[tool.poe.tasks]  # https://github.com/nat-n/poethepoet
+[tool.poe.executor]  # https://github.com/nat-n/poethepoet
+type = "simple"
+
+[tool.poe.tasks]
 {%- if with_fastapi_api %}
 
   [tool.poe.tasks.serve]


### PR DESCRIPTION
Changes:
1. Make the local environment variables `PYTHON_VERSION` and `RESOLUTION_STRATEGY` available in the container for the `postStartCommand`.
2. Set [Poe the Poet's executor type](https://poethepoet.natn.io/global_options.html#change-the-executor-type) to `simple`. Otherwise, it seemingly reapplies `uv sync` before running a task (related: https://github.com/nat-n/poethepoet/pull/271).