### PR TITLE
fix: git ignore uv.lock for packages

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -61,6 +61,11 @@ dist/
 
 # Terraform
 .terraform/
+{%- if project_type == 'package' %}
+
+# uv
+uv.lock
+{%- endif %}
 
 # VS Code
 .vscode/

--- a/template/.pre-commit-config.yaml.jinja
+++ b/template/.pre-commit-config.yaml.jinja
@@ -54,6 +54,7 @@ repos:
         language: system
         stages: [commit-msg]
       {%- endif %}
+      {%- if project_type == 'app' %}
       - id: uv-lock-check
         name: uv lock check
         entry: uv lock
@@ -61,6 +62,7 @@ repos:
         require_serial: true
         language: system
         pass_filenames: false
+      {%- endif %}
       - id: ruff-check
         name: ruff check
         entry: ruff check


### PR DESCRIPTION
Changes:
1. Remove `uv lock --check` from the pre-commit hooks for packages, since these will be tested with various resolution strategies.
2. Add `uv.lock` to `.gitignore` to avoid committing the lock file. The only reason to keep it for package development is perhaps to save some time to solve the environment, but since uv is so fast even that isn't really an argument anymore.