### PR TITLE
feat: simplify publishing to PyPI from GitHub Actions

### DIFF
--- a/template/docker-compose.yml.jinja
+++ b/template/docker-compose.yml.jinja
@@ -3,7 +3,7 @@ services:
   devcontainer:
     build:
       target: dev
-    {%- if project_type == 'package' %}
+    {%- if project_type == 'package' and ci != 'github' %}
     environment:
       - UV_PUBLISH_TOKEN
     {%- endif %}

--- a/template/{% if ci == 'github' %}.github{% endif %}/workflows/{% if project_type == 'package' %}publish.yml{% endif %}.jinja
+++ b/template/{% if ci == 'github' %}.github{% endif %}/workflows/{% if project_type == 'package' %}publish.yml{% endif %}.jinja
@@ -7,15 +7,16 @@ on:
 
 jobs:
   publish:
-    runs-on: ghcr.io/astral-sh/uv:{{ python_version }}-bookworm
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
       - name: Publish package
         run: |
           uv build
           uv publish
-        env:
-          UV_PUBLISH_TOKEN: {% raw %}${{ secrets.UV_PUBLISH_TOKEN }}{% endraw %}


### PR DESCRIPTION
Changes:
1. Simplify the publishing workflow to use the new [Trusted Publisher feature](https://docs.pypi.org/trusted-publishers/adding-a-publisher/). This means you no longer need to create or set a publish token to publish from GitHub Actions.
2. Fix the `runs-on` field and instead install uv, which is not a valid value and [caused the release of Conformal Tights to hang](https://github.com/superlinear-ai/conformal-tights/actions/runs/13792977495).
3. Simplify `docker-compose.yml` by removing the `UV_PUBLISH_TOKEN` unless the project is configured to publish a package without GitHub Actions.