### PR TITLE
fix: add missing permission for trusted publishing

### DIFF
--- a/template/docker-compose.yml.jinja
+++ b/template/docker-compose.yml.jinja
@@ -3,10 +3,6 @@ services:
   devcontainer:
     build:
       target: dev
-    {%- if project_type == 'package' and ci != 'github' %}
-    environment:
-      - UV_PUBLISH_TOKEN
-    {%- endif %}
     volumes:
       - ..:/workspaces
       - command-history-volume:/home/user/.history/

--- a/template/{% if ci == 'github' %}.github{% endif %}/workflows/{% if project_type == 'package' %}publish.yml{% endif %}.jinja
+++ b/template/{% if ci == 'github' %}.github{% endif %}/workflows/{% if project_type == 'package' %}publish.yml{% endif %}.jinja
@@ -8,6 +8,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Changes:
1. Add missing `id-token: write` permission that is necessary for Trusted Publishing [1].
2. Remove the `UV_PUBLISH_TOKEN` altogether since Trusted Publishing is available for several sources, including GitLab.

[1] https://docs.pypi.org/trusted-publishers/using-a-publisher/