### PR TITLE
feat: upgrade to a more modern build system

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -1,3 +1,7 @@
+[build-system]  # https://docs.astral.sh/uv/concepts/projects/config/#build-systems
+requires = ["hatchling>=1.26.0"]
+build-backend = "hatchling.build"
+
 [project]  # https://packaging.python.org/en/latest/specifications/pyproject-toml/
 name = "{{ project_name_kebab_case }}"
 version = "0.0.0"
@@ -145,9 +149,6 @@ max-doc-length = 100
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
-
-[tool.uv]  # https://docs.astral.sh/uv/reference/settings/
-package = true
 
 [tool.poe.executor]  # https://github.com/nat-n/poethepoet
 type = "simple"

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -1,5 +1,5 @@
 [build-system]  # https://docs.astral.sh/uv/concepts/projects/config/#build-systems
-requires = ["hatchling>=1.26.0"]
+requires = ["hatchling>=1.27.0"]
 build-backend = "hatchling.build"
 
 [project]  # https://packaging.python.org/en/latest/specifications/pyproject-toml/


### PR DESCRIPTION
Changes:
1. Configure a modern build system based on [Hatchling v1.26](https://hatch.pypa.io/dev/history/hatchling/), which adds support for core metadata v2.4.
2. Remove the `package = true` uv setting, since it's not necessary if you specify a build system:
    > While uv usually uses the declaration of a [build system](https://docs.astral.sh/uv/concepts/projects/config/#build-systems) to determine if a project should be packaged, uv also allows overriding this behavior with the [tool.uv.package](https://docs.astral.sh/uv/reference/settings/#package) setting.

This is both a fix and a feature: uv's default build system is apparently still setuptools, which does not support some of the more modern core metadata features such as license-file(s). The missing feature can cause publishing to fail—see for example [this failed publish workflow in Conformal Tights](https://github.com/superlinear-ai/conformal-tights/actions/runs/13829693965/job/38691016154). It's recommended to use Hatchling while we wait for [uv's own build system](https://github.com/astral-sh/uv/issues/8779).