### PR TITLE
style: use consistent choices format

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -71,8 +71,8 @@ typing:
   type: str
   help: Do you want to use optional or strict typing and linting?
   choices:
-    Optional: optional
-    Strict: strict
+    - optional
+    - strict
   default: optional
 
 with_conventional_commits:


### PR DESCRIPTION
We use a simple list to choose the `project_type` (either `app` or `package`). This PR does the same for `typing`.