### PR TITLE
fix: close prerequisites details

### DIFF
--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -77,6 +77,8 @@ import {{ project_name_snake_case }}
 1. [Install VS Code](https://code.visualstudio.com/) and [VS Code's Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers). Alternatively, install [PyCharm](https://www.jetbrains.com/pycharm/download/).
 1. _Optional:_ install a [Nerd Font](https://www.nerdfonts.com/font-downloads) such as [FiraCode Nerd Font](https://github.com/ryanoasis/nerd-fonts/tree/master/patched-fonts/FiraCode) and [configure VS Code](https://github.com/tonsky/FiraCode/wiki/VS-Code-Instructions) or [PyCharm](https://github.com/tonsky/FiraCode/wiki/Intellij-products-instructions) to use it.
 
+</details>
+
 <details open>
 <summary>Development environments</summary>
 
@@ -104,7 +106,7 @@ The following development environments are supported:
 
 </details>
 
-<details>
+<details open>
 <summary>Developing</summary>
 {% if with_conventional_commits %}
 - This project follows the [Conventional Commits](https://www.conventionalcommits.org/) standard to automate [Semantic Versioning](https://semver.org/) and [Keep A Changelog](https://keepachangelog.com/) with [Commitizen](https://github.com/commitizen-tools/commitizen).

--- a/{{ cookiecutter.__project_name_kebab_case }}/README.md
+++ b/{{ cookiecutter.__project_name_kebab_case }}/README.md
@@ -156,7 +156,7 @@ The following development environments are supported:
 
 </details>
 
-<details>
+<details open>
 <summary>Developing</summary>
 {% if cookiecutter.with_conventional_commits|int %}
 - This project follows the [Conventional Commits](https://www.conventionalcommits.org/) standard to automate [Semantic Versioning](https://semver.org/) and [Keep A Changelog](https://keepachangelog.com/) with [Commitizen](https://github.com/commitizen-tools/commitizen).


### PR DESCRIPTION
Changes:
1. Add a missing `</details>` to the Prerequisites section.
2. Open the Developing section by default.