### PR TITLE
feat: add support for GitLab CI again

### DIFF
--- a/template/{% if ci == 'gitlab' %}.gitlab-ci.yml{% endif %}.jinja
+++ b/template/{% if ci == 'gitlab' %}.gitlab-ci.yml{% endif %}.jinja
@@ -1,0 +1,60 @@
+stages:
+  - build
+  - test
+
+variables:
+  DOCKER_TLS_CERTDIR: "/certs"
+
+.python_matrix:
+  parallel:
+    matrix:
+      - PYTHON_VERSION: {% if project_type == 'package' %}["3.10", "3.12"]{% else %}["{{ python_version }}"]{% endif %}
+        {% if project_type == 'package' %}RESOLUTION_STRATEGY: ["highest", "lowest-direct"]{%- endif %}
+
+workflow:
+  rules:
+    # Run for pushes to main or master branches
+    - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "master"'
+      when: always
+    # Run for merge requests
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: always
+    # Don't run for other cases like scheduled pipelines or tags unless specified
+    - when: never
+
+build-dev-container:
+  extends:
+    - .python_matrix
+  stage: build
+  image: docker:latest
+  services:
+    - docker:dind
+  before_script:
+    - apk add --update nodejs npm
+    - npm install -g @devcontainers/cli
+  script:
+    - docker login -u gitlab-ci-token -p ${CI_JOB_TOKEN} ${CI_REGISTRY}
+    - IMAGE_TAG="${PYTHON_VERSION}-${RESOLUTION_STRATEGY}"
+    - IMAGE_NAME="${CI_REGISTRY_IMAGE}:${IMAGE_TAG}"
+    - devcontainer build --workspace-folder . --image-name ${IMAGE_NAME}
+    - docker push ${IMAGE_NAME}
+
+test:
+  extends:
+    - .python_matrix
+  stage: test
+  image: ${CI_REGISTRY_IMAGE}:${PYTHON_VERSION}-${RESOLUTION_STRATEGY}
+  script:
+    - uv sync --python $PYTHON_VERSION --resolution $RESOLUTION_STRATEGY --all-extras
+    - poe lint
+    - poe test
+  artifacts:
+    reports:
+      coverage_report:
+        coverage_format: cobertura
+        path: reports/coverage.xml
+      junit:
+        - reports/mypy.xml
+        - reports/pytest.xml
+    untracked: true
+    when: always

--- a/template/{% if ci == 'gitlab' %}.gitlab-ci.yml{% endif %}.jinja
+++ b/template/{% if ci == 'gitlab' %}.gitlab-ci.yml{% endif %}.jinja
@@ -9,7 +9,7 @@ variables:
   parallel:
     matrix:
       - PYTHON_VERSION: {% if project_type == 'package' %}["3.10", "3.12"]{% else %}["{{ python_version }}"]{% endif %}
-        {% if project_type == 'package' %}RESOLUTION_STRATEGY: ["highest", "lowest-direct"]{%- endif %}
+        RESOLUTION_STRATEGY: {% if project_type == 'package' %}["highest", "lowest-direct"]{% else %}["highest"]{%- endif %}
 
 workflow:
   rules:


### PR DESCRIPTION
We want to support GitLab CI in Substrate again. This PR implements the template for the `.gitlab-ci.yml` file.

### Implementation Notes
- GitLab runners (hosted by GitLab) do not allow to run in privileged mode. Thus, it's not possible to use `devcontainer up` directly, as we do in CI on GitHub. 
  - There is a stage `build-dev-container` that builds and pushes the image to GitLab's container registry, and the stage `test` then uses that image. 
- Dependencies are not installed using the `postStartCommand` from the `.devcontainer` configuration directly, but by using `uv sync` within the started devcontainer in the test stage. It's not ideal to have this code duplicated, but I could not find a good way to directly use the devcontainer command. 

### Open TODOs
Have stages for: 
- [x] lint & test
- [ ] build 
- [ ] publish 