### PR TITLE
feat: support mkdocs and add automatic docs deployment for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A modern [Copier template](https://github.com/copier-org/copier) for scaffolding
 - ♻️ Continuous integration with [GitHub Actions](https://docs.github.com/en/actions) or [GitLab CI/CD](https://docs.gitlab.com/ee/ci/)
 - 🧪 Test coverage with [Coverage.py](https://github.com/nedbat/coveragepy)
 - 🧰 Dependency updates with [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates)
+- 📚 Documentation with [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) or [pdoc](https://pdoc.dev/)
 
 ## ✨ Using
 
@@ -90,6 +91,13 @@ To migrate a project from Cookiecutter to Copier, follow these steps:
     ```
 
 5. Create a PR from your branch, review it, and merge it!
+
+## 📚 Generate Docs
+
+If you are using GitHub as your repository host and choose one of the supported documentation frameworks, your docs will be published automatically to GitHub Pages. They will be available at `https://<username>.github.io/<repository>`.
+
+> [!TIP]
+> Ensure the source for GitHub Pages is set to "GitHub Actions" in your repository settings under **Settings** → **Pages**. For more details, see [Configuring a publishing source for your GitHub Pages site](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site).
 
 ## Contributing
 

--- a/copier.yml
+++ b/copier.yml
@@ -91,6 +91,15 @@ with_typer_cli:
   help: Does your {{ project_type }} need a Typer CLI?
   default: false
 
+documentation_tool:
+  type: str
+  help: Which documentation tool do you want to use for your {{ project_type }}?
+  choices:
+    MkDocs (Material theme): mkdocs
+    pdoc: pdoc
+    None: None
+  default: mkdocs
+
 project_name_kebab_case:
   when: false
   default: "{{ project_name | lower | replace(' ', '-') }}"

--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -69,3 +69,14 @@ uv.lock
 
 # VS Code
 .vscode/
+{%- if documentation_tool == 'mkdocs' %}
+
+# MkDocs
+site/
+{%- endif %}
+
+{%- if documentation_tool == 'pdoc' %}
+
+# pdoc
+docs/
+{%- endif %}

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -36,7 +36,13 @@ source = "{{ project_url }}"
 changelog = "{{ project_url.rstrip('/') }}/{% if ci == 'gitlab' %}-/{% endif %}blob/main/CHANGELOG.md"
 {%- endif %}
 releasenotes = "{{ project_url.rstrip('/') }}/{% if ci == 'gitlab' %}-/{% endif %}releases"
+{%- if documentation_tool != 'None' %}
+{%- if ci == 'github' %}
+documentation = "https://{{ project_url.split('/')[-2] }}.github.io/{{ project_url.split('/')[-1] }}"
+{%- else %}
 documentation = "{{ project_url }}"
+{%- endif %}
+{%- endif %}
 issues = "{{ project_url.rstrip('/') }}/{% if ci == 'gitlab' %}-/{% endif %}issues"
 
 [dependency-groups]  # https://docs.astral.sh/uv/concepts/projects/dependencies/#development-dependencies
@@ -49,7 +55,12 @@ dev = [
   "ipython (>=8.18.0)",
   "ipywidgets (>=8.1.2)",
   "mypy (>=1.14.1)",
+  {%- if documentation_tool == 'mkdocs' %}
+  "mkdocs-material (>=9.5.21)",
+  "mkdocstrings[python] (>=0.26.2)",
+  {%- elif documentation_tool == 'pdoc' %}
   "pdoc (>=15.0.1)",
+  {%- endif %}
   {%- if project_type == 'package' %}
   "poethepoet (>=0.32.1)",
   {%- endif %}
@@ -207,8 +218,12 @@ type = "simple"
     cmd = "echo 'Serving app (placeholder)...'"
 {%- endif %}
 
+{%- if documentation_tool != 'None' %}
   [tool.poe.tasks.docs]
   help = "Generate this {{ project_type }}'s docs"
+  {%- if documentation_tool == 'mkdocs' %}
+  cmd = "mkdocs build"
+  {%- elif documentation_tool == 'pdoc' %}
   cmd = """
     pdoc
       --docformat $docformat
@@ -227,6 +242,34 @@ type = "simple"
     name = "outputdirectory"
     options = ["--output-directory"]
     default = "docs"
+  {%- endif %}
+
+  [tool.poe.tasks.docs-serve]
+  help = "Serve the docs locally"
+  {%- if documentation_tool == 'mkdocs' %}
+  cmd = "mkdocs serve"
+  {%- elif documentation_tool == 'pdoc' %}
+  cmd = """
+    pdoc
+      --docformat numpy
+      --host $host
+      --port $port
+      {{ project_name_snake_case }}
+    """
+
+    [[tool.poe.tasks.docs-serve.args]]
+    help = "Bind socket to this host (default: localhost)"
+    name = "host"
+    options = ["--host"]
+    default = "localhost"
+
+    [[tool.poe.tasks.docs-serve.args]]
+    help = "Bind socket to this port (default: 8080)"
+    name = "port"
+    options = ["--port"]
+    default = "8080"
+  {%- endif %}
+{%- endif %}
 
   [tool.poe.tasks.lint]
   help = "Lint this {{ project_type }}"

--- a/template/{% if ci == 'github' %}.github{% endif %}/workflows/{% if documentation_tool != 'None' %}docs.yml{% endif %}.jinja
+++ b/template/{% if ci == 'github' %}.github{% endif %}/workflows/{% if documentation_tool != 'None' %}docs.yml{% endif %}.jinja
@@ -1,0 +1,52 @@
+name: Documentation
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        
+      - name: Set up Python
+        run: uv python install {{ python_version }}
+        
+      - name: Install dependencies
+        run: uv sync --group dev
+        
+      - name: Build docs
+        run: uv run poe docs
+      
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+        
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: {% if documentation_tool == 'mkdocs' %}site{% else %}docs{% endif %}
+          
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ "{{" }} steps.deployment.outputs.page_url {{ "}}" }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/template/{% if documentation_tool == 'mkdocs' %}docs{% endif %}/index.md.jinja
+++ b/template/{% if documentation_tool == 'mkdocs' %}docs{% endif %}/index.md.jinja
@@ -1,0 +1,21 @@
+# {{ project_name }}
+
+{{ project_description }}
+
+## Installation
+
+```bash
+pip install {{ project_name_kebab_case }}
+```
+
+## Quick Start
+
+```python
+import {{ project_name_snake_case }}
+
+# Your code here
+```
+
+## API Reference
+
+See the [API Reference](reference/index.md) for detailed documentation.

--- a/template/{% if documentation_tool == 'mkdocs' %}docs{% endif %}/reference/index.md.jinja
+++ b/template/{% if documentation_tool == 'mkdocs' %}docs{% endif %}/reference/index.md.jinja
@@ -1,0 +1,5 @@
+{% if documentation_tool == 'mkdocs' -%}
+# API Reference
+
+::: {{ project_name_snake_case }}
+{%- endif %}

--- a/template/{% if documentation_tool == 'mkdocs' %}mkdocs.yml{% endif %}.jinja
+++ b/template/{% if documentation_tool == 'mkdocs' %}mkdocs.yml{% endif %}.jinja
@@ -1,0 +1,53 @@
+{% if documentation_tool == 'mkdocs' -%}
+site_name: {{ project_name }}
+site_description: {{ project_description }}
+site_url: {{ project_url }}
+repo_url: {{ project_url }}
+repo_name: {{ project_url.split('/')[-2:] | join('/') }}
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.highlight
+    - search.share
+    - content.code.copy
+  palette:
+    - scheme: default
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+nav:
+  - Home: index.md
+  - API Reference: reference/
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: numpy
+            show_source: true
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+{%- endif %}


### PR DESCRIPTION
This PR adds support for mkdocs (Material Theme) as a documentation framework, and supports automatic deployment of the docs to GitHub Pages

### New features: 
- Added `documentation_tool` question in copier template.
- Based on the answer, required files are created for either `mkdocs` or `pdoc`
- One shared Github Action to deploy the docs for both `mkdocs` or `pdoc`, triggered on push to main

### How to test:
- Create a dummy repository
- Scaffold as normal, selecting a value for `documentation_tool`
- Commit and push to GitHub
- Docs will be available at `https://<username>.github.io/<repository>`

I tested it in this dummy repo here: https://github.com/SimonJasansky/test_substrate 

### Notes: 
- For now, automatic deployment is only supported for repos hosted on Github (not for GitLab). 