### PR TITLE
fix: select user-defined minimum Python version in CI test matrix

### DIFF
--- a/template/{% if ci == 'github' %}.github{% endif %}/workflows/test.yml.jinja
+++ b/template/{% if ci == 'github' %}.github{% endif %}/workflows/test.yml.jinja
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: {% if project_type == 'package' %}["3.10", "3.12"]{% else %}["{{ python_version }}"]{% endif %}
+        python-version: ["{{ python_version }}"]
         {%- if project_type == 'package' %}
         resolution-strategy: ["highest", "lowest-direct"]
         {%- endif %}


### PR DESCRIPTION
Replace hardcoded Python versions [3.10, 3.12] for packages with the user's chosen python_version from copier.yml to ensure compatibility between selected Python version and pyproject.toml requirements.