### PR TITLE
feat: minimize devcontainer.json extensions and settings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,23 +24,20 @@
                 "astral-sh.ty",
                 "charliermarsh.ruff",
                 "DavidAnson.vscode-markdownlint",
-                "GitHub.copilot-chat",
                 "GitHub.vscode-github-actions",
                 "GitHub.vscode-pull-request-github",
-                "ms-azuretools.vscode-docker",
+                "ms-azuretools.vscode-containers",
                 "ms-python.python",
                 "tamasfe.even-better-toml"
             ],
             "settings": {
-                "chat.extensionUnification.enabled": true,
-                "editor.bracketPairColorization.enabled": true,
-                "editor.codeActionsOnSave": {
-                    "source.fixAll": "explicit",
-                    "source.organizeImports": "explicit"
-                },
-                "editor.formatOnSave": true,
                 "[python]": {
-                    "editor.defaultFormatter": "charliermarsh.ruff"
+                    "editor.codeActionsOnSave": {
+                        "source.fixAll.ruff": "explicit",
+                        "source.organizeImports.ruff": "explicit"
+                    },
+                    "editor.defaultFormatter": "charliermarsh.ruff",
+                    "editor.formatOnSave": true
                 },
                 "[toml]": {
                     "editor.formatOnSave": false
@@ -48,24 +45,13 @@
                 "editor.rulers": [
                     100
                 ],
-                "files.autoSave": "onFocusChange",
-                "github.copilot.chat.codesearch.enabled": true,
                 "jupyter.kernels.excludePythonEnvironments": [
                     "/usr/local/bin/python"
                 ],
-                "notebook.codeActionsOnSave": {
-                    "notebook.source.fixAll": "explicit",
-                    "notebook.source.organizeImports": "explicit"
-                },
-                "notebook.formatOnSave.enabled": true,
+                "python-envs.terminal.autoActivationType": "off",
                 "python.defaultInterpreterPath": "/opt/venv/bin/python",
-                "python.languageServer": "None",
-                "python.terminal.activateEnvironment": false,
                 "python.testing.pytestEnabled": true,
                 "terminal.integrated.env.linux": {
-                    "GIT_EDITOR": "code --wait"
-                },
-                "terminal.integrated.env.mac": {
                     "GIT_EDITOR": "code --wait"
                 }
             }

--- a/template/.devcontainer/devcontainer.json.jinja
+++ b/template/.devcontainer/devcontainer.json.jinja
@@ -29,28 +29,25 @@
             "extensions": [
                 "astral-sh.ty",
                 "charliermarsh.ruff",
-                "GitHub.copilot-chat",
                 {%- if ci == 'github' %}
                 "GitHub.vscode-github-actions",
                 "GitHub.vscode-pull-request-github",
                 {%- elif ci == 'gitlab' %}
                 "GitLab.gitlab-workflow",
                 {%- endif %}
-                "ms-azuretools.vscode-docker",
+                "ms-azuretools.vscode-containers",
                 "ms-python.python",
                 "ms-toolsai.jupyter",
                 "tamasfe.even-better-toml"
             ],
             "settings": {
-                "chat.extensionUnification.enabled": true,
-                "editor.bracketPairColorization.enabled": true,
-                "editor.codeActionsOnSave": {
-                    "source.fixAll": "explicit",
-                    "source.organizeImports": "explicit"
-                },
-                "editor.formatOnSave": true,
                 "[python]": {
-                    "editor.defaultFormatter": "charliermarsh.ruff"
+                    "editor.codeActionsOnSave": {
+                        "source.fixAll.ruff": "explicit",
+                        "source.organizeImports.ruff": "explicit"
+                    },
+                    "editor.defaultFormatter": "charliermarsh.ruff",
+                    "editor.formatOnSave": true
                 },
                 "[toml]": {
                     "editor.formatOnSave": false
@@ -58,8 +55,6 @@
                 "editor.rulers": [
                     100
                 ],
-                "files.autoSave": "onFocusChange",
-                "github.copilot.chat.codesearch.enabled": true,
                 "jupyter.kernels.excludePythonEnvironments": [
                     "/usr/local/bin/python"
                 ],
@@ -68,14 +63,10 @@
                     "notebook.source.organizeImports": "explicit"
                 },
                 "notebook.formatOnSave.enabled": true,
+                "python-envs.terminal.autoActivationType": "off",
                 "python.defaultInterpreterPath": "/opt/venv/bin/python",
-                "python.languageServer": "None",
-                "python.terminal.activateEnvironment": false,
                 "python.testing.pytestEnabled": true,
                 "terminal.integrated.env.linux": {
-                    "GIT_EDITOR": "code --wait"
-                },
-                "terminal.integrated.env.mac": {
                     "GIT_EDITOR": "code --wait"
                 }
             }


### PR DESCRIPTION
Changes:
- Remove redundant and obsolete VS Code extensions and settings.
- Use current Container Tools and Python environment configuration.
- Scope Ruff save actions to Python while preserving notebook support.